### PR TITLE
Add version check of handshake protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TODO
 - [x] no unwrap, expect
 - [ ] 2 hour auto delete
     - for rolling update
-- [ ] add test, which checks api version field
+- [x] add test, which checks api version field
 - [x] remove client id from client hello
 - [x] add error in server hello
 - [x] handle error in server_hello

--- a/proxy_client/src/error.rs
+++ b/proxy_client/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("Server encountered some errors.")]
     InternalServerError,
 
+    #[error("Current client handshake version is not supported.")]
+    ClientHandshakeVersionMismatch,
+
     #[error("Server sent a malformed message.")]
     MalformedMessageFromServer,
 

--- a/proxy_lib/src/lib.rs
+++ b/proxy_lib/src/lib.rs
@@ -2,6 +2,8 @@ use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
+pub const CLIENT_HELLO_VERSION: u16 = 0;
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(transparent)]
 pub struct StreamId(pub [u8; 8]);
@@ -127,12 +129,12 @@ pub enum ServerHello {
     Success {
         client_id: ClientId,
         assigned_port: u16,
-        version: u16,
     },
     BadRequest,
     ServiceTemporaryUnavailable,
     IllegalHost,
     InternalServerError,
+    VersionMismatch,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
client hello で handshake version を提示すると、サーバーは accept するか `ServerHello::VersionMismatch` を返す。
server hello の version はおそらく不要なので削除した。
server hello の中身を変えたいときは client hello の version に対して VersionMismatch を返すようにして、 Client のアップデートを促す