### PR TITLE
Use CancellationToken in proxy-server instead of oneshot channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-tungstenite 0.14.0",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/proxy_server/Cargo.toml
+++ b/proxy_server/Cargo.toml
@@ -11,6 +11,7 @@ magic_tunnel_lib = { version = "0.1.1", path = "../proxy_lib" }
 magic_tunnel_client = { version = "0.1.2", path = "../proxy_client" }
 tokio-tungstenite = { version = '0.14', features = ["rustls"] }
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.6.8"
 futures = "0.3"
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/proxy_server/src/main.rs
+++ b/proxy_server/src/main.rs
@@ -3,12 +3,13 @@ use lazy_static::lazy_static;
 use magic_tunnel_lib::ClientId;
 pub use magic_tunnel_server::{
     active_stream::ActiveStreams, connected_clients::Connections, port_allocator::PortAllocator,
-    proxy_server::run, remote::CancelHander,
+    proxy_server::run,
     Config,
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use once_cell::sync::OnceCell;
+use tokio_util::sync::CancellationToken;
 
 lazy_static! {
     pub static ref CONNECTIONS: Connections = Connections::new();
@@ -44,7 +45,7 @@ async fn main() {
     };
 
     let alloc = Arc::new(Mutex::new(PortAllocator::new(remote_port_start..remote_port_end)));
-    let remote_cancellers: Arc<DashMap<ClientId, CancelHander>> = Arc::new(DashMap::new());
+    let remote_cancellers: Arc<DashMap<ClientId, CancellationToken>> = Arc::new(DashMap::new());
     let handle = run(
         &CONFIG,
         &CONNECTIONS,

--- a/proxy_server/src/proxy_server.rs
+++ b/proxy_server/src/proxy_server.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use once_cell::sync::OnceCell;
+use tokio_util::sync::CancellationToken;
 
 use crate::active_stream::ActiveStreams;
 use crate::connected_clients::Connections;
 use crate::control_server;
 use crate::port_allocator::PortAllocator;
-use crate::remote::CancelHander;
 use crate::{Config, ProxyServerError};
 
 pub async fn run(
@@ -18,7 +18,7 @@ pub async fn run(
     conn: &'static Connections,
     active_streams: &'static ActiveStreams,
     alloc: Arc<Mutex<PortAllocator<Range<u16>>>>,
-    remote_cancellers: Arc<DashMap<ClientId, CancelHander>>,
+    remote_cancellers: Arc<DashMap<ClientId, CancellationToken>>,
 ) -> Result<JoinHandle<()>, ProxyServerError> {
     tracing::info!("starting server!");
 

--- a/proxy_test/tests/integrated_test.rs
+++ b/proxy_test/tests/integrated_test.rs
@@ -11,7 +11,7 @@ use magic_tunnel_server::{
     connected_clients::Connections,
     port_allocator::PortAllocator,
     proxy_server,
-    remote::{CancelHander, HTTP_TUNNEL_REFUSED_RESPONSE},
+    remote::HTTP_TUNNEL_REFUSED_RESPONSE,
     Config,
 };
 use magic_tunnel_auth::build_routes;
@@ -92,7 +92,7 @@ mod proxy_client_server_test {
             }
         );
         let alloc = Arc::new(Mutex::new(PortAllocator::new(config.remote_port_start..config.remote_port_end)));
-        let remote_cancellers: Arc<DashMap<ClientId, CancelHander>> = Arc::new(DashMap::new());
+        let remote_cancellers: Arc<DashMap<ClientId, CancellationToken>> = Arc::new(DashMap::new());
 
         tokio::spawn(async move {
             proxy_server::run(

--- a/proxy_test/tests/proxy_server_test.rs
+++ b/proxy_test/tests/proxy_server_test.rs
@@ -6,7 +6,7 @@ use magic_tunnel_client::proxy_client::{send_client_hello, verify_server_hello, 
 use magic_tunnel_lib::{ClientId, ControlPacket};
 use magic_tunnel_server::{
     active_stream::ActiveStreams, connected_clients::Connections, port_allocator::PortAllocator,
-    proxy_server::run, remote::CancelHander,
+    proxy_server::run,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +19,7 @@ use once_cell::sync::OnceCell;
 use magic_tunnel_server::Config;
 use magic_tunnel_auth::make_jwt;
 use chrono::Duration as CDuration;
+use tokio_util::sync::CancellationToken;
 
 #[cfg(test)]
 mod proxy_server_test {
@@ -86,7 +87,7 @@ mod proxy_server_test {
         Connections::clear(&CONNECTIONS);
         ACTIVE_STREAMS.clear();
         let alloc = Arc::new(Mutex::new(PortAllocator::new(config.remote_port_start..config.remote_port_end)));
-        let remote_cancellers: Arc<DashMap<ClientId, CancelHander>> = Arc::new(DashMap::new());
+        let remote_cancellers: Arc<DashMap<ClientId, CancellationToken>> = Arc::new(DashMap::new());
 
         tokio::spawn(async move {
             run(


### PR DESCRIPTION
#8 
CancellationToken を使う前は oneshot::channel を使っていたが、 CancellationToken に統一する