### PR TITLE
add client-local api

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ ownserver  -- --payload tcp --local-port 25565
 
 share your public URL!
 
+### Use the client API to inspect endpoints and streams
+You can query endpoints and streams info using the client API.  
+You need to specify local port to use the API: 
+
+```
+% ownserver --payload tcp --local-port 3000 --api-port 9000
+
+% curl -s localhost:9000/endpoints
+[{"id":"client_be38a93b-b7a9-46da-9d9d-51df95cad828","local_port":3000,"remote_addr":"shard-5346.ownserver.kumassy.com:13574"}]
+% curl -s localhost:9000/streams
+[{"id":"stream_24a3b5bb-336d-4b4e-baf3-7ef61bc1b78c"}]
+```
+
 ## How it works
 
 ![](/docs/img/overview.svg)

--- a/ownserver/src/api.rs
+++ b/ownserver/src/api.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use futures::Future;
+use warp::Filter;
+
+use crate::{Store, proxy_client::ClientInfo};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct Endpoint {
+    id: String,
+    local_port: u16,
+    remote_addr: String,
+}
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct Stream {
+    id: String,
+}
+
+pub fn spawn_api(store: Arc<Store>, api_port: u16, local_port: u16, client_info: ClientInfo) -> impl Future<Output = ()> {
+    let endpoints = warp::path("endpoints").map(move || {
+        let endpoint = Endpoint {
+            id: client_info.client_id.to_string(),
+            local_port,
+            remote_addr: client_info.remote_addr.to_string(),
+        };
+        warp::reply::json(&vec![endpoint])
+    });
+    let streams = warp::path("streams").map(move || {
+        let streams = store.list_streams()
+            .iter()
+            .map(|id| Stream {
+                id: id.to_string(),
+            })
+            .collect::<Vec<Stream>>();
+        warp::reply::json(
+            &streams
+        )
+    });
+    let routes = warp::get().and(
+        endpoints
+            .or(streams)
+    );
+    warp::serve(routes).run(([127, 0, 0, 1], api_port))
+}

--- a/ownserver/src/lib.rs
+++ b/ownserver/src/lib.rs
@@ -12,7 +12,7 @@ pub mod error;
 pub mod local;
 pub mod localudp;
 pub mod proxy_client;
-
+pub mod api;
 
 pub type LocalStream = UnboundedSender<StreamMessage>;
 #[derive(Debug, Default)]
@@ -43,5 +43,9 @@ impl Store {
 
     pub fn len_stream(&self) -> usize {
         self.streams.len()
+    }
+
+    pub fn list_streams(&self) -> Vec<StreamId> {
+        self.streams.iter().map(|x| *x.key()).collect()
     }
 }

--- a/ownserver/src/main.rs
+++ b/ownserver/src/main.rs
@@ -1,10 +1,11 @@
+use std::sync::Arc;
 use anyhow::Result;
 use log::*;
 use ownserver_lib::Payload;
 use tokio_util::sync::CancellationToken;
 use structopt::StructOpt;
 
-use ownserver::proxy_client::run;
+use ownserver::{proxy_client::run, api, Store};
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "ownserver")]
@@ -13,7 +14,8 @@ struct Opt {
     local_port: u16,
     #[structopt(long, default_value = "tcp", help = "tcp or udp")]
     payload: String,
-
+    #[structopt(long, help = "Advanced settings. You can inspect client's internal state at localhost:<api_port>.")]
+    api_port: Option<u16>,
 
     #[structopt(long, default_value = "5000", help = "Advanced settings")]
     control_port: u16,
@@ -33,14 +35,21 @@ async fn main() -> Result<()> {
     };
     debug!("{:?}", payload);
 
-    let store = Default::default();
+    let store: Arc<Store> = Default::default();
     let cancellation_token = CancellationToken::new();
 
+    let store_ = store.clone();
     let (client_info, mut set) =
-        run(store, opt.control_port, opt.local_port, &opt.token_server, payload, cancellation_token).await?;
+        run(store_, opt.control_port, opt.local_port, &opt.token_server, payload, cancellation_token).await?;
     info!("client is running under configuration: {:?}", client_info);
 
-
+    if let Some(api_port) = opt.api_port {
+        info!("client side api is available at localhost:{}", api_port);
+        set.spawn(async move {
+            api::spawn_api(store, api_port, opt.local_port, client_info).await;
+            Ok(())
+        });
+    }
 
     while let Some(res) = set.join_next().await {
         match res {


### PR DESCRIPTION
Allow user to inspect client status https://github.com/Kumassy/ownserver/issues/45.

Currently, the API has two endpoints: 
```

$ curl -s localhost:9000/endpoints
[{"id":"client_be38a93b-b7a9-46da-9d9d-51df95cad828","local_port":3000,"remote_addr":"shard-5346.ownserver.kumassy.com:13574"}]


$ curl -s localhost:9000/streams
[{"id":"stream_24a3b5bb-336d-4b4e-baf3-7ef61bc1b78c"}]
```