### PR TITLE
Add guest address info to client

### DIFF
--- a/ownserver/src/api.rs
+++ b/ownserver/src/api.rs
@@ -5,11 +5,6 @@ use warp::Filter;
 
 use crate::Store;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct Stream {
-    id: String,
-}
-
 pub fn spawn_api(store: Arc<Store>, api_port: u16) -> impl Future<Output = ()> {
     let store_ = store.clone();
     let rtt = warp::path("rtt").map(move || {
@@ -22,12 +17,7 @@ pub fn spawn_api(store: Arc<Store>, api_port: u16) -> impl Future<Output = ()> {
         warp::reply::json(&vec![endpoints])
     });
     let streams = warp::path("streams").map(move || {
-        let streams = store.list_streams()
-            .iter()
-            .map(|id| Stream {
-                id: id.to_string(),
-            })
-            .collect::<Vec<Stream>>();
+        let streams = store.list_streams();
         warp::reply::json(
             &streams
         )

--- a/ownserver/src/local/tcp.rs
+++ b/ownserver/src/local/tcp.rs
@@ -8,9 +8,9 @@ use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
 use tokio::io::{ReadHalf, WriteHalf};
 use tokio::net::TcpStream;
 
-use crate::{StreamMessage, Store};
+use crate::{LocalStream, Store, StreamMessage};
 use log::*;
-use ownserver_lib::{StreamId, EndpointId, ControlPacketV2};
+use ownserver_lib::{ControlPacketV2, EndpointId, RemoteInfo, StreamId};
 
 /// Establish a new local stream and start processing messages to it
 pub async fn setup_new_stream(
@@ -18,6 +18,7 @@ pub async fn setup_new_stream(
     mut tunnel_tx: UnboundedSender<ControlPacketV2>,
     stream_id: StreamId,
     endpoint_id: EndpointId,
+    remote_info: RemoteInfo,
 ) -> io::Result<()> {
     info!("sid={} eid={} setting up local tcp stream", stream_id, endpoint_id);
     let local_addr = store.get_local_addr_by_endpoint_id(endpoint_id).ok_or(io::Error::from(ErrorKind::Other))?;
@@ -42,7 +43,8 @@ pub async fn setup_new_stream(
 
     // Forward remote packets to local tcp
     let (tx, rx) = unbounded();
-    store.add_stream(stream_id, tx);
+    let local_stream = LocalStream::new(tx, remote_info);
+    store.add_stream(stream_id, local_stream);
     info!("sid={} insert stream to active_streams. len={}", &stream_id, store.len_stream());
 
     tokio::spawn(async move {

--- a/ownserver/src/proxy_client.rs
+++ b/ownserver/src/proxy_client.rs
@@ -257,8 +257,9 @@ pub async fn process_control_flow_message(
         // TODO: should handle None case
 
     match control_packet {
-        ControlPacketV2::Init(stream_id, endpoint_id) => {
-            debug!("sid={} eid={} init stream", stream_id, endpoint_id);
+        // TODO: use remote_info
+        ControlPacketV2::Init(stream_id, endpoint_id, ref remote_info) => {
+            debug!("sid={} eid={} remote_info={} init stream", stream_id, endpoint_id, remote_info);
 
             let endpoint = match store.get_endpoint_by_endpoint_id(endpoint_id) {
                 Some(e) => e,

--- a/ownserver_lib/src/lib.rs
+++ b/ownserver_lib/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, net::SocketAddr};
 
 use bytes::BytesMut;
 use chrono::DateTime;
@@ -88,7 +88,7 @@ pub struct ClientHelloV2 {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ControlPacketV2 {
-    Init(StreamId, EndpointId),
+    Init(StreamId, EndpointId, RemoteInfo),
     Data(StreamId, Vec<u8>),
     Refused(StreamId),
     End(StreamId),
@@ -99,7 +99,7 @@ pub enum ControlPacketV2 {
 impl std::fmt::Display for ControlPacketV2 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
          match self {
-            ControlPacketV2::Init(sid, eid) => write!(f, "ControlPacket::Init(sid={}, eid={})", sid, eid),
+            ControlPacketV2::Init(sid, eid, remote_info) => write!(f, "ControlPacket::Init(sid={}, eid={}, remote_info={})", sid, eid, remote_info),
             ControlPacketV2::Data(sid, data) => write!(f, "ControlPacket::Data(sid={}, data_len={})", sid,  data.len()),
             ControlPacketV2::Refused(sid)  => write!(f, "ControlPacket::Refused(sid={})", sid),
             ControlPacketV2::End(sid) => write!(f, "ControlPacket::End(sid={})", sid),
@@ -118,6 +118,17 @@ pub struct Endpoint {
 }
 
 pub type Endpoints = Vec<Endpoint>;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RemoteInfo {
+    pub remote_addr: SocketAddr,
+}
+
+impl std::fmt::Display for RemoteInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RemoteInfo(remote_addr={}", self.remote_addr)
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]

--- a/ownserver_lib/src/lib.rs
+++ b/ownserver_lib/src/lib.rs
@@ -121,12 +121,18 @@ pub type Endpoints = Vec<Endpoint>;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RemoteInfo {
-    pub remote_addr: SocketAddr,
+    pub remote_peer_addr: SocketAddr,
+}
+
+impl RemoteInfo {
+    pub fn new(remote_peer_addr: SocketAddr) -> Self {
+        Self { remote_peer_addr }
+    }
 }
 
 impl std::fmt::Display for RemoteInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RemoteInfo(remote_addr={}", self.remote_addr)
+        write!(f, "RemoteInfo(remote_peer_addr={}", self.remote_peer_addr)
     }
 }
 
@@ -190,13 +196,14 @@ mod control_packet_test {
     fn test_control_packet_init() -> Result<(), Box<dyn std::error::Error>> {
         let stream_id = StreamId::default();
         let endpoint_id = EndpointId::default();
-        let expected_packet = ControlPacketV2::Init(stream_id, endpoint_id);
+        let remote_info = RemoteInfo::new("127.0.0.1:8080".parse()?);
+        let expected_packet = ControlPacketV2::Init(stream_id, endpoint_id, remote_info);
 
         let mut encoded = BytesMut::new();
         ControlPacketV2Codec::new().encode(expected_packet, &mut encoded)?;
 
         let deserialized_packet = ControlPacketV2Codec::new().decode(&mut encoded)?.unwrap();
-        assert_eq!(ControlPacketV2::Init(stream_id, endpoint_id), deserialized_packet);
+        assert_eq!(ControlPacketV2::Init(stream_id, endpoint_id, RemoteInfo::new("127.0.0.1:8080".parse()?)), deserialized_packet);
         Ok(())
     }
 }

--- a/ownserver_server/src/client.rs
+++ b/ownserver_server/src/client.rs
@@ -94,8 +94,8 @@ impl Client {
                                 gauge!("ownserver_server.stream.rtt", rtt, "client_id" => client_id.to_string());
                                 continue;
                             }
-                            ControlPacketV2::Init(stream_id, endpoint_id) => {
-                                tracing::error!(cid = %client_id, sid = %stream_id, eid = %endpoint_id, "invalid protocol ControlPacketV2::Init");
+                            ControlPacketV2::Init(stream_id, endpoint_id, remote_info) => {
+                                tracing::error!(cid = %client_id, sid = %stream_id, eid = %endpoint_id, remote_info = %remote_info, "invalid protocol ControlPacketV2::Init");
                                 continue;
                             }
                             ControlPacketV2::End(stream_id) => {


### PR DESCRIPTION
- Add remote peer address to `ControlPacketV2::Init`
  - Clients can introspects remote peer address via local API